### PR TITLE
Input components onChange callback

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -17,6 +17,7 @@ function Button({
   rightElement = null,
   disabled = false,
   onClick = () => {},
+  type,
 }: ButtonProps): ReactElement {
   /**
    * @function renderLeftElement
@@ -79,6 +80,7 @@ function Button({
       variant={variant}
       size={size}
       onClick={onClick}
+      type={type}
     >
       <styled.Container>
         {leftElement && <styled.LeftElement>{renderLeftElement}</styled.LeftElement>}

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -93,7 +93,7 @@ export const Layout = styled.button<LayoutProps>`
     cursor: default;
   }
 
-  ${({ size, variant, withElements, onlyIcon }: any) => `
+  ${({ size, variant, withElements, onlyIcon }) => `
  
      ${styledIf(
        onlyIcon,

--- a/src/components/inputs/Button/types.ts
+++ b/src/components/inputs/Button/types.ts
@@ -22,4 +22,5 @@ export type ButtonProps = {
   rightElement?: ReactElement<any> | String | null;
   disabled?: boolean;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"];
 };

--- a/src/components/inputs/InputAmount/index.tsx
+++ b/src/components/inputs/InputAmount/index.tsx
@@ -28,12 +28,14 @@ import { InputAmountProps, TokenItem } from "./types";
 function InputAmount(
   {
     onChange,
+    onBlur,
     tokens = [],
     error = null,
     disabled = false,
     initialTokenIndex = 0,
     label = "Amount to Withdraw",
     value = BigNumber.from(0),
+    name,
   }: InputAmountProps,
   inputRef: React.Ref<any>,
 ) {
@@ -86,10 +88,7 @@ function InputAmount(
       if (decimals <= 18) {
         const number = BigNumber.from(parseUnits(value === "" ? "0.0" : value, 18));
         setInputValue(value);
-        onChange({
-          value: number,
-          token: selectedToken,
-        });
+        onChange(e, { value: number, token: selectedToken });
       }
     },
     [selectedToken],
@@ -138,7 +137,9 @@ function InputAmount(
             type={"text"}
             placeholder={"0.0"}
             onChange={handleTextChange}
+            onBlur={onBlur}
             disabled={disabled}
+            name={name}
           />
           {selectedToken && tokens && <MaxButton onClick={onClickMaxValue}>Max</MaxButton>}
         </Side>

--- a/src/components/inputs/InputAmount/types.ts
+++ b/src/components/inputs/InputAmount/types.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "ethers";
+import { ChangeEventHandler } from "react";
 
 export type TokenItem = {
   id: string | number;
@@ -7,12 +8,14 @@ export type TokenItem = {
   balance: string | number;
 };
 
-export type InputAmountProps = {
+export interface InputAmountProps {
   label: string;
   value: BigNumber;
   onChange: Function;
+  onBlur?: ChangeEventHandler<HTMLInputElement>;
   disabled: boolean;
   tokens?: TokenItem[];
   error?: string | null;
   initialTokenIndex?: number;
-};
+  name?: string;
+}


### PR DESCRIPTION
Currently, for the inputAmount component, we call the onChange callback with this data:

```
onChange({
  value: number,
  token: selectedToken,
});
```

However this breaks React Hook Form as you can see here: https://codesandbox.io/s/react-hook-form-js-forked-wou9lm?file=/src/App.js

Because RHF expects to receive the event in the callback, using `event.target.name` internally.

My PR modifies the onChange callback to pass the event as the first parameter (like with mui), and a custom value as the 2nd one.
```
onChange(e, { value: number, token: selectedToken });
```

If we agree to go this way, we need to think about the other inputs. For the simple text input, this would work:
```
onChange(e);
// The value can be retrived with e.target.value
// Or we can explicitly adds the value as the 2nd param
onChange(e, value);
```

It would be possible to use a Controller component from RHF but I think it complicates things because we would need one for all the input components.

With Formik I think we'd have similar issues I think. I noticed [here](https://github.com/zignaly-open/zignaly-bridge-webapp/blob/ft/web3-react/packages/react-app/src/components/forms/TransferForm/index.jsx#L305) @german-schneck you are calling `setValue` manually and there is a way to do it with RHF (`setValue`):
```
onChange={(item) => {
  setValue("amount", item.value, { shouldValidate: true });
}}
```

We would need to do that for all the input components so I'm not sure if it's a good solution.

Let me know if you have suggestions.

I have also added the following props to inputAmount: onBlur, name.
They are needed by RHF, so we'll need to add them for our other inputs.