### PR TITLE
fix(typescript-description): fix declarations on typescript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
+    "checkJs": false,
     "target": "es2021",
     "module": "esnext",
-    "declaration": true,
-    "outDir": "./lib",
     "strict": true,
     "jsx": "react",
     "esModuleInterop": true,
@@ -17,11 +16,13 @@
         "name": "typescript-styled-plugin"
       }
     ],
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "lib",
+    "declarationMap": true
   },
-  "include": [
-    "src",
-    "./jest-setup.ts"
-  ],
+  "include": ["src/**/*"],
   "exclude": [
     "node_modules"
   ],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15254932/170789657-b30bfec9-f088-4c56-828a-c8d74eb3e63b.png)


Now zignaly-ui is recognized on the IDE and don't shows warnings or errors.