### PR TITLE
fix(Modas): Fix actions button styling

### DIFF
--- a/src/components/modals/styles.ts
+++ b/src/components/modals/styles.ts
@@ -1,11 +1,10 @@
 // Dependencies
 import styled from "styled-components";
 
-export const Actions = styled.div`
+export const Actions = styled.div<{ align?: string }>`
+  display: flex;
   width: 100%;
-  display: grid;
-  grid-row-gap: 22px;
-  grid-column-gap: 22px;
-  grid-template-columns: repeat(${(props: any) => props.columns}, minmax(0%, 100%));
+  gap: 22px;
   margin-top: 26px;
+  justify-content: ${({ align }) => align || "center"};
 `;


### PR DESCRIPTION
When using the Actions styled-components, it forced the button to be full width. Now it should be better, like:

Before:
![image](https://user-images.githubusercontent.com/5314435/174522073-c27ccea9-27aa-428a-8ec3-480e491afe56.png)

After:
![image](https://user-images.githubusercontent.com/5314435/174522080-e663d06e-cf80-4f9c-bc74-d8fdc08d47bf.png)
